### PR TITLE
Update peerDependencies to support Grunt 1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,10 +15,12 @@
     "url": "https://github.com/viatsyshyn/grunt-jsbuild3/issues"
   },
   "license": "MIT",
-  "licenses": [{
-    "type": "MIT",
-    "url": "https://github.com/viatsyshyn/grunt-jsbuild3/blob/master/LICENSE"
-  }],
+  "licenses": [
+    {
+      "type": "MIT",
+      "url": "https://github.com/viatsyshyn/grunt-jsbuild3/blob/master/LICENSE"
+    }
+  ],
   "main": "Gruntfile.js",
   "engines": {
     "node": "0.10.0"
@@ -35,7 +37,7 @@
     "grunt-text-replace": "^0.4.0"
   },
   "peerDependencies": {
-    "grunt": "~0.4.2",
+    "grunt": ">=0.4.0",
     "emp.ria-jsbuild3": "^0.1.14"
   },
   "keywords": [


### PR DESCRIPTION
Update peerDependencies to support Grunt 1.0

Hello,

This is an automated issue request to update the `peerDependencies` for your Grunt plugin.
We ask you to merge this and **publish a new release on npm** to get your plugin working in Grunt 1.0!

Read more here: http://gruntjs.com/blog/2016-02-11-grunt-1.0.0-rc1-released#peer-dependencies
Also on Twitter: https://twitter.com/gruntjs/status/700819604155707392

If you have any questions or you no longer have time to maintain this plugin, then please let us know in this thread.

Thanks for creating and working on this plugin!

(P.S. Close this PR if it is a mistake, sorry)
